### PR TITLE
INT8 decoder quantization for Metal

### DIFF
--- a/MODEL.md
+++ b/MODEL.md
@@ -201,7 +201,8 @@ Plus `norm.weight [3072]` (final norm). NO biases in decoder.
 ## Decoder Forward Pass
 
 The Metal backend quantizes all decoder matmul weights from BF16 to per-group symmetric
-INT8 at runtime (group_size=128, scales cached). The encoder stays F16/MPS.
+INT8 (group_size=128). Quantized weights are cached to disk (int8_cache.bin) and reused
+on subsequent runs. The encoder stays F16/MPS.
 
 Per-layer computation for hidden state `h` at positions `pos .. pos+seq-1`:
 

--- a/MODEL.md
+++ b/MODEL.md
@@ -200,6 +200,9 @@ Plus `norm.weight [3072]` (final norm). NO biases in decoder.
 
 ## Decoder Forward Pass
 
+The Metal backend quantizes all decoder matmul weights from BF16 to per-group symmetric
+INT8 at runtime (group_size=128, scales cached). The encoder stays F16/MPS.
+
 Per-layer computation for hidden state `h` at positions `pos .. pos+seq-1`:
 
 1. **Attention RMSNorm**: `x = RMSNorm(h, attention_norm, eps=1e-5)`

--- a/voxtral.c
+++ b/voxtral.c
@@ -191,40 +191,27 @@ vox_ctx_t *vox_load(const char *model_dir) {
         vox_metal_warmup_bf16(ctx->adapter.linear1_weight_bf16,
                               (size_t)VOX_DEC_DIM * VOX_DEC_DIM);
 
-        /* Decoder weights (26 layers) */
+        /* Pre-warm INT8 weight caches for decoder */
         for (int i = 0; i < VOX_DEC_LAYERS; i++) {
             vox_dec_layer_t *l = &ctx->decoder.layers[i];
-            size_t dec_q  = (size_t)(VOX_DEC_HEADS * VOX_DEC_HEAD_DIM) * VOX_DEC_DIM;
-            size_t dec_kv = (size_t)(VOX_DEC_KV_HEADS * VOX_DEC_HEAD_DIM) * VOX_DEC_DIM;
-            size_t dec_wo = (size_t)VOX_DEC_DIM * (VOX_DEC_HEADS * VOX_DEC_HEAD_DIM);
-            size_t dec_f1 = (size_t)VOX_DEC_HIDDEN * VOX_DEC_DIM;
-            size_t dec_f2 = (size_t)VOX_DEC_DIM * VOX_DEC_HIDDEN;
-            vox_metal_warmup_bf16(l->wq_weight_bf16, dec_q);
-            vox_metal_warmup_bf16(l->wk_weight_bf16, dec_kv);
-            vox_metal_warmup_bf16(l->wv_weight_bf16, dec_kv);
-            vox_metal_warmup_bf16(l->wo_weight_bf16, dec_wo);
-            vox_metal_warmup_bf16(l->w1_weight_bf16, dec_f1);
-            vox_metal_warmup_bf16(l->w2_weight_bf16, dec_f2);
-            vox_metal_warmup_bf16(l->w3_weight_bf16, dec_f1);
+            vox_metal_warmup_int8(l->wq_weight_bf16,
+                (size_t)(VOX_DEC_HEADS * VOX_DEC_HEAD_DIM) * VOX_DEC_DIM, VOX_DEC_DIM);
+            vox_metal_warmup_int8(l->wk_weight_bf16,
+                (size_t)(VOX_DEC_KV_HEADS * VOX_DEC_HEAD_DIM) * VOX_DEC_DIM, VOX_DEC_DIM);
+            vox_metal_warmup_int8(l->wv_weight_bf16,
+                (size_t)(VOX_DEC_KV_HEADS * VOX_DEC_HEAD_DIM) * VOX_DEC_DIM, VOX_DEC_DIM);
+            vox_metal_warmup_int8(l->wo_weight_bf16,
+                (size_t)VOX_DEC_DIM * (VOX_DEC_HEADS * VOX_DEC_HEAD_DIM),
+                VOX_DEC_HEADS * VOX_DEC_HEAD_DIM);
+            vox_metal_warmup_int8(l->w1_weight_bf16,
+                (size_t)VOX_DEC_HIDDEN * VOX_DEC_DIM, VOX_DEC_DIM);
+            vox_metal_warmup_int8(l->w2_weight_bf16,
+                (size_t)VOX_DEC_DIM * VOX_DEC_HIDDEN, VOX_DEC_HIDDEN);
+            vox_metal_warmup_int8(l->w3_weight_bf16,
+                (size_t)VOX_DEC_HIDDEN * VOX_DEC_DIM, VOX_DEC_DIM);
         }
-
-        /* Token embeddings (also used as logits projection) */
-        vox_metal_warmup_bf16(ctx->decoder.tok_embeddings_bf16,
-                              (size_t)VOX_VOCAB_SIZE * VOX_DEC_DIM);
-
-        /* Pre-warm merged weight buffers for monolithic decoder step */
-        for (int i = 0; i < VOX_DEC_LAYERS; i++) {
-            vox_dec_layer_t *l = &ctx->decoder.layers[i];
-            /* Merged QKV = wq + wk + wv */
-            vox_metal_warmup_merged_3(
-                l->wq_weight_bf16, (size_t)(VOX_DEC_HEADS * VOX_DEC_HEAD_DIM) * VOX_DEC_DIM,
-                l->wk_weight_bf16, (size_t)(VOX_DEC_KV_HEADS * VOX_DEC_HEAD_DIM) * VOX_DEC_DIM,
-                l->wv_weight_bf16, (size_t)(VOX_DEC_KV_HEADS * VOX_DEC_HEAD_DIM) * VOX_DEC_DIM);
-            /* Merged w1+w3 */
-            vox_metal_warmup_merged_2(
-                l->w1_weight_bf16, (size_t)VOX_DEC_HIDDEN * VOX_DEC_DIM,
-                l->w3_weight_bf16, (size_t)VOX_DEC_HIDDEN * VOX_DEC_DIM);
-        }
+        vox_metal_warmup_int8(ctx->decoder.tok_embeddings_bf16,
+            (size_t)VOX_VOCAB_SIZE * VOX_DEC_DIM, VOX_DEC_DIM);
 
         /* Pre-warm decoder MPS ops and f32 weight caches */
         vox_metal_warmup_decoder_ops(ctx);

--- a/voxtral.c
+++ b/voxtral.c
@@ -192,6 +192,7 @@ vox_ctx_t *vox_load(const char *model_dir) {
                               (size_t)VOX_DEC_DIM * VOX_DEC_DIM);
 
         /* Pre-warm INT8 weight caches for decoder */
+        int int8_cached = vox_metal_load_int8_cache(model_dir);
         for (int i = 0; i < VOX_DEC_LAYERS; i++) {
             vox_dec_layer_t *l = &ctx->decoder.layers[i];
             vox_metal_warmup_int8(l->wq_weight_bf16,
@@ -212,6 +213,8 @@ vox_ctx_t *vox_load(const char *model_dir) {
         }
         vox_metal_warmup_int8(ctx->decoder.tok_embeddings_bf16,
             (size_t)VOX_VOCAB_SIZE * VOX_DEC_DIM, VOX_DEC_DIM);
+        if (!int8_cached)
+            vox_metal_save_int8_cache(model_dir);
 
         /* Pre-warm decoder MPS ops and f32 weight caches */
         vox_metal_warmup_decoder_ops(ctx);

--- a/voxtral_metal.h
+++ b/voxtral_metal.h
@@ -181,6 +181,12 @@ size_t vox_metal_memory_used(void);
 /* Pre-warm INT8 weight cache for a decoder weight tensor. */
 void vox_metal_warmup_int8(const uint16_t *bf16_weights, size_t num_elements, int K);
 
+/* Load pre-quantized INT8 weights from disk cache. Returns 1 on success. */
+int vox_metal_load_int8_cache(const char *model_dir);
+
+/* Save quantized INT8 weights to disk cache for fast subsequent loads. */
+void vox_metal_save_int8_cache(const char *model_dir);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This patch implements weight-only INT8 quantization for all decoder matmuls, using a custom Metal compute kernel (per-group symmetric, group_size=128). The encoder stays F16/MPS unchanged.

I don't believe that on Apple Silicon we should see significant additional gains from quantizing activations, since the decoder is memory-bandwidth bound, not compute bound. INT8 halves the weight traffic per matmul, which is where the speedup comes from. Quantizing activations wouldn't help reduce that, even if Apple Silicon had INT8 tensor cores.

Since INT8 uses less memory, is significantly faster, and the test suite passes identically (however the test suite here is not a good sample in my opinion), I made INT8 the only Metal decoder path and removed the dead BF16 Metal decoder functions. All decoder matmul weight tensors are quantized uniformly, including tok_embeddings.

With per group symmetric quantization (`group_size=128`), each weight's rounding error is bounded by half the quantization step. In practice the accumulated perturbation stays well below typical argmax margins. `128` matches head_dim and divides every decoder weight K dimension evenly.

INT8 weights are cached to disk (`int8_cache.bin` in the model directory) so quantization only runs on the first load; subsequent runs skip it entirely. The cache includes a staleness check against the safetensors file so it auto-regenerates if the model changes.

There could be additional gains by also quantizing the encoder however I didn't want to mess with it because it's not where the majority of the gain is and it would double the complexity of this patch.



Note: I observe gains in encoding, however they usually are not from encoder code changes. They are  likely a side effect of reduced GPU memory pressure from the decoder weights.
